### PR TITLE
Add 'add_movie' option to Radarr config

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,14 @@ collections:
       - https://trakt.tv/users/2borno2b/lists/christmas-movies-extravanganza
   Marvel:
     trakt-list: https://trakt.tv/users/movistapp/lists/marvel
+  Pixar:
+    studio: Pixar
+    details:
+      summary: A collection of Pixar movies
+  1990s:
+    year: [1990,1991,1992,1993,1994,1995,1996,1997,1998,1999]
+    details:
+      summary: A collection of 1990s movies
 plex:
   library: Movies
   library_type: movie # or 'show'
@@ -120,7 +128,8 @@ radarr:
   token: ################ 
   quality_profile_id: 4
   root_folder_path: /mnt/user/PlexMedia/movies
-  search: true
+  add_movie: false
+  search_movie: false
 tmdb:
   apikey: ################ 
   language: en

--- a/config.yml.template
+++ b/config.yml.template
@@ -16,6 +16,14 @@ collections:
       tmdb-summary: 4169
   Marvel:
     trakt-list: https://trakt.tv/users/movistapp/lists/marvel
+  Pixar:
+    studio: Pixar
+    details:
+      summary: A collection of Pixar movies
+  1990s:
+    year: [1990,1991,1992,1993,1994,1995,1996,1997,1998,1999]
+    details:
+      summary: A collection of 1990s movies
 plex:
   library: Movies
   library_type: ### 'movie' or 'show' ###
@@ -26,7 +34,8 @@ radarr:
   token: ###########################
   quality_profile_id: 4
   root_folder_path: /mnt/user/PlexMedia/movies
-  search: false
+  add_movie: false
+  search_movie: false
 tmdb:
   apikey: ############################
   language: en

--- a/config_tools.py
+++ b/config_tools.py
@@ -56,8 +56,20 @@ class Radarr:
         config = Config(config_path).radarr
         self.url = config['url']
         self.token = config['token']
-        self.quality = config['quality_profile_id']
-
+        self.quality_profile_id = config['quality_profile_id']
+        self.root_folder_path = config['root_folder_path']
+        # Set 'add_movie' to None if not set
+        if 'add_movie' in config: 
+            self.add_movie = config['add_movie']
+        else:
+            self.add_movie = None
+        # Support synonyms 'search_movie' and 'search'; add logical default to False
+        if 'search_movie' in config:
+            self.search_movie = config['search_movie']
+        elif 'search' in config:
+            self.search_movie = config['search']
+        else:
+            self.search_movie = False
 
 class TMDB:
     def __init__(self, config_path):
@@ -92,7 +104,7 @@ class ImageServer:
         except:
             a = 1
 
-def update_from_config(config_path, plex, skip_radarr=False):
+def update_from_config(config_path, plex):
     config = Config(config_path)
     collections = config.collections
     if isinstance(plex.Library, MovieSection):
@@ -137,7 +149,11 @@ def update_from_config(config_path, plex, skip_radarr=False):
                         else:
                             method_name = "TMDb"
                         print("{} missing movies from {} List: {}".format(len(missing), method_name, v))
-                        if not skip_radarr:
+                        if 'add_movie' in config.radarr:
+                            if config.radarr['add_movie'] is True:
+                                print("Adding missing movies to Radarr")
+                                add_to_radarr(config_path, missing)
+                        else:
                             if input("Add missing movies to Radarr? (y/n): ").upper() == "Y":
                                 add_to_radarr(config_path, missing)
                     elif libtype == "show":

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 PyYAML==5.1.2
 tmdbv3api
 lxml
-requests
+requests>=2.4.2
 flask
 git+git://github.com/pkkid/python-plexapi.git#egg=plexapi
 trakt.py


### PR DESCRIPTION
Added the ability to set `add_movie` in `config.yml` in order to automatically add all missing movies to Radarr (closes #16). I'll eventually add the functionality to set `add_movie` by the collection instead for all collections.

Additionally, I added some example collections to the readme and template config (closes #12).