### PR TITLE
Add logic to find config.yml

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,6 @@
 FROM python:3.8-slim
 VOLUME /config
-COPY /app/. /app
-COPY /config/. /config
-COPY /requirements.txt /requirements.txt
+COPY . /
 RUN \
 	echo "**** install system packages ****" && \
 		apt-get update && \
@@ -21,4 +19,4 @@ RUN \
 			/var/tmp/* \
 			/var/lib/apt/lists/*
 WORKDIR /app
-ENTRYPOINT ["python3", "plex_auto_collections.py", "--config_path", "/config/config.yml", "--update"]
+ENTRYPOINT ["python3", "plex_auto_collections.py", "--update"]

--- a/README.md
+++ b/README.md
@@ -28,19 +28,19 @@ To run the script in an interactive terminal run:
 python plex_auto_collections.py
 ```
     
-If you would like to run the script without any user interaction (e.g. to schedule the script to run on a schedule) the script can be launched with:
+If you would like to run the script without any user interaction (e.g. to schedule the script to run on a schedule) the script can be launched with `-u` or `--update`:
 
 ```shell
 python plex_auto_collections.py --update
 ```
 
-If you would like to run without the image server try:
+If you would like to run without the image server try using `-ns` or `--no-server`:
 
 ```shell
-python plex_auto_collections.py --noserver
+python plex_auto_collections.py --no-server
 ```
     
-A different configuration file can be specified with the `-c <path_to_config>` or `--config_path <path_to_config>`. This is useful for creating collections against different libraries, such as a Movie and TV library. In this case, be sure to update the `library_type` in the configuration file.
+A different configuration file can be specified with the `-c <path_to_config>` or `--config-path <path_to_config>`. This is useful for creating collections against different libraries, such as a Movie and TV library. In this case, be sure to update the `library_type` in the configuration file.
 
 ```shell
 python plex_auto_collections.py -c <path_to_config>

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ python plex_auto_collections.py --no-server
 A different configuration file can be specified with the `-c <path_to_config>` or `--config-path <path_to_config>`. This is useful for creating collections against different libraries, such as a Movie and TV library. In this case, be sure to update the `library_type` in the configuration file.
 
 ```shell
-python plex_auto_collections.py -c <path_to_config>
+python plex_auto_collections.py --config-path <path_to_config>
 ```
 
 ## Docker

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ If you would like to run without the image server try using `-ns` or `--no-serve
 python plex_auto_collections.py --no-server
 ```
     
-A different configuration file can be specified with the `-c <path_to_config>` or `--config-path <path_to_config>`. This is useful for creating collections against different libraries, such as a Movie and TV library. In this case, be sure to update the `library_type` in the configuration file.
+A `config.yml` file is required to run the script. The script checks for a `config.yml` file alongside `plex_auto_collections.py` as well as in `config/config.yml`. If desired, a different configuration file can be specified with `-c <path_to_config>` or `--config-path <path_to_config>`. This could be useful for creating collections against different libraries, such as a Movie and TV library (in this case, be sure to update the `library_type` in the configuration file).
 
 ```shell
 python plex_auto_collections.py --config-path <path_to_config>

--- a/app/config_tools.py
+++ b/app/config_tools.py
@@ -133,25 +133,29 @@ class ImageServer:
             self.port = 5000
         # Test and set default folder path
         if mode == "server":
+            print("Attempting to find posters directory")
+            
             if 'poster-directory' in config:
                 self.posterdirectory = config['poster-directory']
             else:
                 app_dir = os.path.dirname(os.path.realpath(__file__))
 
-                # Test separate config folder with nested 'posters' folder
+                # Test separate config directory with nested 'posters' directory
                 if os.path.exists(os.path.join(app_dir, "..", "config", "posters")):
                     self.posterdirectory = os.path.join("..", "config", "posters")
-                # Test separate config folder with nested 'images' folder
+                # Test separate config folder with nested 'images' directory
                 elif os.path.exists(os.path.join(app_dir, "..", "config", "images")):
                     self.posterdirectory = os.path.join("..", "config", "images")            
-                # Test nested posters folder
+                # Test nested posters directory
                 elif os.path.exists(os.path.join(app_dir, "posters")):
                     self.posterdirectory = "posters"
-                # Test nested images folder
+                # Test nested images directory
                 elif os.path.exists(os.path.join(app_dir, "images")):
                     self.posterdirectory = "images"
                 else:
                     raise RuntimeError("Invalid poster-directory setting")
+            
+            print("Using {} as poster directory".format(self.posterdirectory))
 
 
 def update_from_config(config_path, plex, headless=False):

--- a/app/plex_auto_collections.py
+++ b/app/plex_auto_collections.py
@@ -1,3 +1,4 @@
+import os
 import argparse
 import sys
 import threading
@@ -178,30 +179,48 @@ if hasattr(__builtins__, 'raw_input'):
     input = raw_input
 
 parser = argparse.ArgumentParser()
-parser.add_argument("-c", "--config_path",
-                    help="Configuration file",
+parser.add_argument("-c", "--config-path", "--config_path",
+                    dest="config_path",
+                    help="Run with desired config.yml file",
                     nargs='?',
                     const=1,
-                    type=str,
-                    default="config.yml")
+                    type=str)
 parser.add_argument("-u", "--update",
-                    help="Automatically update collections off config and quits",
+                    help="Update collections using config without user interaction",
                     action="store_true")
-parser.add_argument("-ns", "--noserver",
-                    help="Don't start the image server",
+parser.add_argument("-ns", "--no-server", "--noserver",
+                    dest="no_server",
+                    help="Run without the image server",
                     action="store_true")
 
 args = parser.parse_args()
 
-
 print("==================================================================")
-print(" Plex Auto Collections by /u/iRawrz  ")
+print(" Plex Auto Collections                                            ")
 print("==================================================================")
 
-config_path = args.config_path
+print("Attempting to find config")
+config_path = None
+app_dir = os.path.dirname(os.path.realpath(__file__))
+
+# Set config_path from command line switch
+if args.config_path and os.path.exists(args.config_path):
+    config_path = args.config_path
+# Set config_path from app_dir
+elif os.path.exists(os.path.join(app_dir, "config.yml")):
+    config_path = os.path.join(app_dir, "config.yml")
+# Set config_path from config_dir
+elif os.path.exists(os.path.join(app_dir, "..", "config", "config.yml")):
+    config_path = os.path.join(app_dir, "..", "config", "config.yml")
+else:
+    print("No config found, exiting")
+    sys.exit(1)
+
+print("Using {} as config".format(config_path))
+
 plex = Plex(config_path)
 
-if not args.noserver:
+if not args.no_server:
     print("Attempting to start image server")
     pid = threading.Thread(target=image_server.start_srv, args=(config_path,))
     pid.daemon = True


### PR DESCRIPTION
The script was still defaulting to looking for `config.yml` alongside `plex_auto_collections.py`. This adds some logic to search there as well as in the `config` folder (closes #39).