### PR TITLE
[Bug Fix] Addresses filter problems

### DIFF
--- a/app/plex_auto_collections.py
+++ b/app/plex_auto_collections.py
@@ -11,7 +11,7 @@ try:
     from plexapi.video import Show
     from plexapi.library import MovieSection
     from plexapi.library import ShowSection
-    from plexapi.library import Collections
+    from plexapi.collection import Collections
     from plex_tools import get_map
     from plex_tools import add_to_collection
     from plex_tools import delete_collection

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 # Remove
 PyYAML==5.3.1
 # Less common, pinned
-PlexAPI==4.2.0
+PlexAPI==4.5.1
 tmdbv3api==1.7.4
 trakt.py==4.2.0
 # More common, flexible


### PR DESCRIPTION
Updates PlexAPI to version 4.5.1 in requirements.txt and changes the import in plex_auto_collection.py from `plexapi.library` to `plexapi.collection` to reflect API changes. The filter solution is tested and working with Plex Media Server version 1.22.1.4228. 

The test involved organizing collections by decade and by director Steven Spielberg.

Fixes #212 